### PR TITLE
remove try-catch to significantly improve performance

### DIFF
--- a/bloom.js
+++ b/bloom.js
@@ -58,7 +58,6 @@ JSBloom.filter = function(items, target_prob) {
 
     addEntry = function(str) {
 
-        try {
             var indices = hashes.getIndices(str);
 
             for (var i = indices.length - 1; i >= 0; i--) {
@@ -75,10 +74,6 @@ JSBloom.filter = function(items, target_prob) {
             };
 
             return true;
-        } catch (err) {
-            throw Error(err);
-        }
-
     }
 
     addEntries = function(arr) {
@@ -92,20 +87,21 @@ JSBloom.filter = function(items, target_prob) {
     }
 
     checkEntry = function(str) {
+
         var indices = hashes.getIndices(str);
 
-            for (var i = indices.length - 1; i >= 0; i--) {
-                var extra_indices = indices[i] % 8,
-                    index = (indices[i] - extra_indices) / 8;
+        for (var i = indices.length - 1; i >= 0; i--) {
+            var extra_indices = indices[i] % 8,
+                index = (indices[i] - extra_indices) / 8;
 
-                if (extra_indices != 0 && (bVector[index] & (128 >> (extra_indices - 1))) == 0) {
-                    return false;
-                } else if (extra_indices == 0 && (bVector[index] & 1) == 0) {
-                    return false;
-                }
-            };
+            if (extra_indices != 0 && (bVector[index] & (128 >> (extra_indices - 1))) == 0) {
+                return false;
+            } else if (extra_indices == 0 && (bVector[index] & 1) == 0) {
+                return false;
+            }
+        };
 
-            return true;
+        return true;
     }
 
     importData = function(lzData, k) {
@@ -152,3 +148,4 @@ JSBloom.filter = function(items, target_prob) {
 if (typeof exports !== "undefined") {
     exports.filter = JSBloom.filter;
 };
+

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,20 @@ describe('JSBloom - Bloom Filter', function() {
 
     });
 
+    describe('Non-Existence', function() {
+        it('should return false for 1000 non elements', function() {
+            var positive = 0;
+            for (var i = 1000 - 1; i >= 0; i--) {
+                if(filter.checkEntry(generator()))
+                    positive ++;
+            };
+            assert.ok(positive <= 10, 'should have had less than 10 positive tests, but had:'+positive);
+        });
+
+    });
+
+
+
     describe('Import & Export', function() {
         it('should return true on predefined element in imported array', function() {
             filter.importData(importData);
@@ -88,3 +102,9 @@ describe('JSBloom - Bloom Filter', function() {
     });
 
 });
+
+
+
+
+
+


### PR DESCRIPTION
I've been benchmarking the various bloomfilter implementations available on npm, and this one is very good!

However, the try-catch in `checkEntry` is not necessary, (and also harder for the v8 engine to optimize) 
and removing it makes this module the fastest bloomfilter available in node, even compared to CPP implementations!

below are the results of my benchmark:
```
module-name, add, +test, -test
jsbloom_notrycatch, 219780, 225225, 238663 ## this PR
jsbloom, 171233, 230947, 238095
bloom-filter-cpp, 218818, 210970, 235294
bloomfilter, 170068, 170068, 173310
bloom-lite, 77151, 114811, 103520
bloem, 72493, 76923, 78218
bloom-filter-js, 16441, 16865, 16346
bloomxx, 556, 564, 5372
```
the benchmark was run on a lenovo x201

my bench mark code is up at https://github.com/dominictarr/bloom-bench