### PR TITLE
feature: addEntry returns whether the item was added

### DIFF
--- a/bloom.js
+++ b/bloom.js
@@ -44,6 +44,7 @@ JSBloom.filter = function(items, target_prob) {
 
         var h1 = hashes.djb2(str)
         var h2 = hashes.sdbm(str)
+        var added = false
         for (var round = 0; round <= HASH_ROUNDS; round++) {
             var new_hash = round == 0 ? h1
                          : round == 1 ? h2
@@ -54,13 +55,15 @@ JSBloom.filter = function(items, target_prob) {
 
             if (extra_indices != 0 && (bVector[index] & (128 >> (extra_indices - 1))) == 0) {
                 bVector[index] ^= (128 >> extra_indices - 1);
+                added = true;
             } else if (extra_indices == 0 && (bVector[index] & 1) == 0) {
                 bVector[index] ^= 1;
+                added = true;
             }
 
         };
 
-        return true;
+        return added;
     }
 
     addEntries = function(arr) {

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,16 @@ describe('JSBloom - Bloom Filter', function() {
 
     });
 
+    describe('Duplicate Insertion', function() {
+        it('should return true for 2000 added elements', function() {
+            for (var i = test_entries.length - 1; i >= 0; i--) {
+                assert.equal(filter.addEntry(test_entries[i]), false);
+            };
+        });
+
+    });
+
+
     describe('Non-Existence', function() {
         it('should return false for 1000 non elements', function() {
             var positive = 0;


### PR DESCRIPTION
this change makes it easy to use jsbloom as a counter. addEntry now returns false if the item was already in the set. This makes it easy to keep a counter of total elements added, and total unique items added.

This change does not effect performance significantly, since the implementation already tests for membership before updating.